### PR TITLE
feat: add basic auth for logs endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ show collections
 - `JWT_SECRET`: Secret key for JWT token generation
 - `OPENAI_API_KEY`: OpenAI API key for AI features
 - `APP_CORS_ALLOWED_ORIGINS`: Allowed CORS origins
+- `LOGS_BASIC_USERNAME`: Username for Basic auth on `/logs` endpoints
+- `LOGS_BASIC_PASSWORD`: Password for Basic auth on `/logs` endpoints
 
 #### Admin Panel Configuration
 - `API_BASE_URL`: Base URL of the API backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-your-openai-api-key}
       JWT_SECRET: ${JWT_SECRET:-mySecretKeyForDevelopmentPleaseChangeInProduction123456789012345678901234567890}
       APP_CORS_ALLOWED_ORIGINS: ${APP_CORS_ALLOWED_ORIGINS:-http://localhost:8082,http://localhost:8083}
+      LOGS_BASIC_USERNAME: ${LOGS_BASIC_USERNAME:-logs}
+      LOGS_BASIC_PASSWORD: ${LOGS_BASIC_PASSWORD:-logs}
     ports:
       - "8088:8088"
     healthcheck:

--- a/mindfit-api/src/main/java/com/mindfit/api/config/OpenApiConfig.java
+++ b/mindfit-api/src/main/java/com/mindfit/api/config/OpenApiConfig.java
@@ -19,7 +19,11 @@ public class OpenApiConfig {
                                 new SecurityScheme()
                                         .type(SecurityScheme.Type.HTTP)
                                         .scheme("bearer")
-                                        .bearerFormat("JWT")))
+                                        .bearerFormat("JWT"))
+                        .addSecuritySchemes("basicAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("basic")))
                 .info(new Info()
                         .title("Mindfit API")
                         .description("Spring Boot + MongoDB backend for fitness/diet system")

--- a/mindfit-api/src/main/java/com/mindfit/api/config/SecurityConfig.java
+++ b/mindfit-api/src/main/java/com/mindfit/api/config/SecurityConfig.java
@@ -4,8 +4,8 @@ import com.mindfit.api.filter.JwtAuthenticationFilter;
 import com.mindfit.api.service.UserDetailsServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -24,6 +24,11 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.Arrays;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 
 @Configuration
 @EnableWebSecurity
@@ -37,9 +42,24 @@ public class SecurityConfig {
     @Value("${app.cors.allowed-origins}")
     private String allowedOrigins;
 
+    @Value("${LOGS_BASIC_USERNAME:logs}")
+    private String logsUsername;
+
+    @Value("${LOGS_BASIC_PASSWORD:logs}")
+    private String logsPassword;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public UserDetailsService logsUserDetailsService() {
+        UserDetails user = User.withUsername(logsUsername)
+                .password(passwordEncoder().encode(logsPassword))
+                .roles("ADMIN")
+                .build();
+        return new InMemoryUserDetailsManager(user);
     }
 
     @Bean
@@ -51,12 +71,36 @@ public class SecurityConfig {
     }
 
     @Bean
+    public DaoAuthenticationProvider logsAuthenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(logsUserDetailsService());
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
         return config.getAuthenticationManager();
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Order(1)
+    public SecurityFilterChain logsFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/logs/**")
+                .cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth.anyRequest().hasAnyRole("ADMIN", "SUPER_ADMIN"))
+                .httpBasic(Customizer.withDefaults())
+                .authenticationProvider(logsAuthenticationProvider());
+
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
         http
                 .cors(Customizer.withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
@@ -68,7 +112,6 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/api-docs/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/health/**").permitAll()
-                        .requestMatchers("/logs/**").hasAnyRole("ADMIN", "SUPER_ADMIN")
                         .anyRequest().authenticated()
                 )
                 .authenticationProvider(authenticationProvider())

--- a/mindfit-api/src/main/java/com/mindfit/api/controller/LogController.java
+++ b/mindfit-api/src/main/java/com/mindfit/api/controller/LogController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/logs")
 @RequiredArgsConstructor
 @Tag(name = "Logs", description = "Log management API")
-@SecurityRequirement(name = "bearerAuth")
+@SecurityRequirement(name = "basicAuth")
 public class LogController {
 
     private final LogService logService;


### PR DESCRIPTION
## Summary
- configure `/logs` basic auth credentials via LOGS_BASIC_USERNAME and LOGS_BASIC_PASSWORD env vars
- pass logs credentials to API container and document variables

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3eec22088333aa172a095ea19698