### PR TITLE
Expose logs retrieval without auth and remove log creation API

### DIFF
--- a/mindfit-api/src/main/java/com/mindfit/api/controller/LogController.java
+++ b/mindfit-api/src/main/java/com/mindfit/api/controller/LogController.java
@@ -1,31 +1,26 @@
 package com.mindfit.api.controller;
 
-import com.mindfit.api.dto.LogCreateRequest;
 import com.mindfit.api.dto.LogResponse;
 import com.mindfit.api.service.LogService;
 import com.mindfit.api.mapper.LogMapper;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/logs")
 @RequiredArgsConstructor
 @Tag(name = "Logs", description = "Log management API")
-@SecurityRequirement(name = "basicAuth")
 public class LogController {
 
     private final LogService logService;
     private final LogMapper logMapper;
 
     @GetMapping
-    @Operation(summary = "Get all logs (Admin only)")
+    @Operation(summary = "Get all logs")
     public Page<LogResponse> getAllLogs(
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate,
@@ -38,19 +33,11 @@ public class LogController {
     }
 
     @GetMapping("/{id}")
-    @Operation(summary = "Get log by ID (Admin only)")
+    @Operation(summary = "Get log by ID")
     public LogResponse getLogById(
             @PathVariable String id) {
 
         return logMapper.toResponse(logService.findById(id));
     }
 
-    @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    @Operation(summary = "Create new log (Admin only)")
-    public LogResponse createLog(
-            @Valid @RequestBody LogCreateRequest request) {
-
-        return logMapper.toResponse(logService.create(request));
-}
 }

--- a/mindfit-api/src/main/java/com/mindfit/api/service/LogService.java
+++ b/mindfit-api/src/main/java/com/mindfit/api/service/LogService.java
@@ -1,7 +1,6 @@
 package com.mindfit.api.service;
 
 import com.mindfit.api.common.exception.ResourceNotFoundException;
-import com.mindfit.api.common.exception.UnauthorizedException;
 import com.mindfit.api.common.exception.BadRequestException;
 import com.mindfit.api.dto.LogCreateRequest;
 import com.mindfit.api.dto.LogDto;
@@ -9,7 +8,6 @@ import com.mindfit.api.enums.LogType;
 import com.mindfit.api.model.Log;
 import com.mindfit.api.repository.LogRepository;
 import com.mindfit.api.mapper.LogMapper;
-import com.mindfit.api.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -34,9 +32,10 @@ public class LogService {
     }
 
     public Page<LogDto> findAll(String startDate, String endDate, String type, String category, Pageable pageable) {
-        if (!SecurityUtil.isAdmin()) {
-            throw new UnauthorizedException("Only admins can view logs");
-        }
+        // Authentication temporarily disabled for testing
+        // if (!SecurityUtil.isAdmin()) {
+        //     throw new UnauthorizedException("Only admins can view logs");
+        // }
 
         LogType logType = null;
         if (type != null && !type.isBlank()) {
@@ -85,9 +84,10 @@ public class LogService {
     }
 
     public LogDto findById(String id) {
-        if (!SecurityUtil.isAdmin()) {
-            throw new UnauthorizedException("Only admins can view logs");
-        }
+        // Authentication temporarily disabled for testing
+        // if (!SecurityUtil.isAdmin()) {
+        //     throw new UnauthorizedException("Only admins can view logs");
+        // }
         
         Log log = logRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Log not found with id: " + id));
@@ -95,14 +95,6 @@ public class LogService {
         return logMapper.toDto(log);
     }
 
-    public LogDto create(LogCreateRequest request) {
-        if (!SecurityUtil.isAdmin()) {
-            throw new UnauthorizedException("Only admins can create logs");
-        }
-
-        return logMapper.toDto(logRepository.save(logMapper.toEntity(request)));
-    }
-    
     public void logApiCall(String endpoint, String method, String details) {
         try {
             LogCreateRequest request = new LogCreateRequest(


### PR DESCRIPTION
## Summary
- drop POST /logs endpoint so logs are only programmatically created
- bypass admin check for log retrieval endpoints during testing

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.mindfit:api:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5287ca5883338b7445a2615a8e2f